### PR TITLE
Make the localization module function the same as the other modules. …

### DIFF
--- a/resources/lang/en/button.php
+++ b/resources/lang/en/button.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'new_language' => 'New Language',
+    'new_zone' => 'New Zone',
+    'new_country' => 'New Country',
+    'new_state' => 'New State',
+    'new_currency' => 'New Currency',
+];

--- a/src/Http/Controller/Admin/LanguagesController.php
+++ b/src/Http/Controller/Admin/LanguagesController.php
@@ -17,17 +17,6 @@ class LanguagesController extends AdminController
 {
 
     /**
-     * Redirect to languages.
-     *
-     * @param Redirector $redirector
-     * @return \Illuminate\Http\RedirectResponse
-     */
-    public function redirect(Redirector $redirector)
-    {
-        return $redirector->to('admin/localization/languages');
-    }
-
-    /**
      * Return an index of existing entries.
      *
      * @param LanguageTableBuilder $table

--- a/src/LocalizationModule.php
+++ b/src/LocalizationModule.php
@@ -28,27 +28,27 @@ class LocalizationModule extends Module
     protected $sections = [
         'languages'  => [
             'buttons' => [
-                'create'
+                'new_language'
             ]
         ],
         'zones'      => [
             'buttons' => [
-                'create'
+                'new_zone'
             ]
         ],
         'countries'  => [
             'buttons' => [
-                'create'
+                'new_country'
             ]
         ],
         'states'     => [
             'buttons' => [
-                'create'
+                'new_state'
             ]
         ],
         'currencies' => [
             'buttons' => [
-                'create'
+                'new_currency'
             ]
         ]
     ];

--- a/src/LocalizationModuleServiceProvider.php
+++ b/src/LocalizationModuleServiceProvider.php
@@ -54,16 +54,15 @@ class LocalizationModuleServiceProvider extends AddonServiceProvider
      * @var array
      */
     protected $routes = [
-        'admin/localization'                      => 'Anomaly\LocalizationModule\Http\Controller\Admin\LanguagesController@redirect',
+        'admin/localization'                      => 'Anomaly\LocalizationModule\Http\Controller\Admin\LanguagesController@index',
+        'admin/localization/create'               => 'Anomaly\LocalizationModule\Http\Controller\Admin\LanguagesController@create',
+        'admin/localization/edit/{id}'            => 'Anomaly\LocalizationModule\Http\Controller\Admin\LanguagesController@edit',
         'admin/localization/countries'            => 'Anomaly\LocalizationModule\Http\Controller\Admin\CountriesController@index',
         'admin/localization/countries/create'     => 'Anomaly\LocalizationModule\Http\Controller\Admin\CountriesController@create',
         'admin/localization/countries/edit/{id}'  => 'Anomaly\LocalizationModule\Http\Controller\Admin\CountriesController@edit',
         'admin/localization/currencies'           => 'Anomaly\LocalizationModule\Http\Controller\Admin\CurrenciesController@index',
         'admin/localization/currencies/create'    => 'Anomaly\LocalizationModule\Http\Controller\Admin\CurrenciesController@create',
         'admin/localization/currencies/edit/{id}' => 'Anomaly\LocalizationModule\Http\Controller\Admin\CurrenciesController@edit',
-        'admin/localization/languages'            => 'Anomaly\LocalizationModule\Http\Controller\Admin\LanguagesController@index',
-        'admin/localization/languages/create'     => 'Anomaly\LocalizationModule\Http\Controller\Admin\LanguagesController@create',
-        'admin/localization/languages/edit/{id}'  => 'Anomaly\LocalizationModule\Http\Controller\Admin\LanguagesController@edit',
         'admin/localization/states'               => 'Anomaly\LocalizationModule\Http\Controller\Admin\StatesController@index',
         'admin/localization/states/create'        => 'Anomaly\LocalizationModule\Http\Controller\Admin\StatesController@create',
         'admin/localization/states/edit/{id}'     => 'Anomaly\LocalizationModule\Http\Controller\Admin\StatesController@edit',


### PR DESCRIPTION
…Namely rather than redirecting to /localization/language for the root page it uses /localization for the homepage. This fixes the broken link on the create button on the homepage. Second all the buttons are updated to use the new_ format rather than create and the associated buttons.php lang file has been created.
